### PR TITLE
Added Chocolatey and Scoop install options to the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ If you rename it you can register with a different name and have multiple instal
 #### 2. Install .cer to "Trusted Root Certification Authorities" of the local machine
 [For details, please refer to the wiki](https://github.com/yuk7/ArchWSL/wiki/Install-Certificate)
 
+You need administrator privileges to install the certificate
+
 ### 🍫 Chocolatey
 `choco install wsl-archlinux`
 
@@ -47,7 +49,6 @@ If you rename it you can register with a different name and have multiple instal
 
 `scoop install archwsl `
 
-You need administrator privileges to install the certificate
 #### 3. Install .appx
 
 ## 📝How-to-Use(for Installed Instance)

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ If you rename it you can register with a different name and have multiple instal
 [For details, please refer to the wiki](https://github.com/yuk7/ArchWSL/wiki/Install-Certificate)
 
 You need administrator privileges to install the certificate
+#### 3. Install .appx
 
 ### 🍫 Chocolatey
 `choco install wsl-archlinux`
@@ -48,8 +49,6 @@ You need administrator privileges to install the certificate
 `scoop bucket add extras `
 
 `scoop install archwsl `
-
-#### 3. Install .appx
 
 ## 📝How-to-Use(for Installed Instance)
 #### exe Usage

--- a/README.md
+++ b/README.md
@@ -42,9 +42,6 @@ If you rename it you can register with a different name and have multiple instal
 You need administrator privileges to install the certificate
 #### 3. Install .appx
 
-### 🍫 Chocolatey
-`choco install wsl-archlinux`
-
 ### 🥄 Scoop
 `scoop bucket add extras `
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,14 @@ If you rename it you can register with a different name and have multiple instal
 #### 2. Install .cer to "Trusted Root Certification Authorities" of the local machine
 [For details, please refer to the wiki](https://github.com/yuk7/ArchWSL/wiki/Install-Certificate)
 
+### 🍫 Chocolatey
+`choco install wsl-archlinux`
+
+### 🥄 Scoop
+`scoop bucket add extras `
+
+`scoop install archwsl `
+
 You need administrator privileges to install the certificate
 #### 3. Install .appx
 


### PR DESCRIPTION
Seeing as both managers have the archWSL as a package and they work very well (tested myself) I thought they could be mentioned in the official README